### PR TITLE
Some updates to get the example to build and run on Windows.

### DIFF
--- a/allegro-sys/build.rs
+++ b/allegro-sys/build.rs
@@ -34,7 +34,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro-{}{}{}{}{}", version, monolith, static_, "-mt", debug);
     }
     else

--- a/allegro-sys/build.rs
+++ b/allegro-sys/build.rs
@@ -29,5 +29,16 @@ fn main()
 		Ok(_) => "-monolith"
 	};
 
-	println!("cargo:rustc-flags=-l allegro{}{}{}", monolith, static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro-{}{}{}{}{}", version, monolith, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro{}{}{}", monolith, static_, debug);
+    }
 }

--- a/allegro-sys/src/macros.rs
+++ b/allegro-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro-sys/src/rust_util.rs
+++ b/allegro-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro/src/macros.rs
+++ b/allegro/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro/src/rust_util.rs
+++ b/allegro/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_acodec-sys/build.rs
+++ b/allegro_acodec-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_acodec{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_acodec-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro_acodec{}{}", static_, debug);
+    }
 }

--- a/allegro_acodec-sys/build.rs
+++ b/allegro_acodec-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_acodec-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_acodec-sys/src/rust_util.rs
+++ b/allegro_acodec-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_acodec/src/lib.rs
+++ b/allegro_acodec/src/lib.rs
@@ -40,7 +40,8 @@ impl AcodecAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(AcodecAddon)
 				}
 			}
@@ -49,7 +50,8 @@ impl AcodecAddon
 				if al_init_acodec_addon() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(AcodecAddon)
 				}
 				else

--- a/allegro_acodec/src/lib.rs
+++ b/allegro_acodec/src/lib.rs
@@ -40,7 +40,7 @@ impl AcodecAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(AcodecAddon)
 				}
@@ -50,7 +50,7 @@ impl AcodecAddon
 				if al_init_acodec_addon() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(AcodecAddon)
 				}

--- a/allegro_acodec/src/lib.rs
+++ b/allegro_acodec/src/lib.rs
@@ -7,17 +7,18 @@
 
 #![feature(thread_local)]
 #![feature(optin_builtin_traits)]
+#![allow(non_upper_case_globals)]
 
 extern crate allegro;
 extern crate allegro_audio;
 extern crate "allegro_acodec-sys" as allegro_acodec_sys;
 
+use std::cell::RefCell;
 use allegro_audio::AudioAddon;
 use allegro_acodec_sys::*;
 
 static mut initialized: bool = false;
-#[thread_local]
-static mut spawned_on_this_thread: bool = false;
+thread_local!(static spawned_on_this_thread: RefCell<bool> = RefCell::new(false));
 
 #[allow(missing_copy_implementations)]
 pub struct AcodecAddon;
@@ -34,14 +35,13 @@ impl AcodecAddon
 		{
 			if initialized
 			{
-				if spawned_on_this_thread
+				if spawned_on_this_thread.with(|x| *x.borrow())
 				{
 					Err("The acodec addon has already been created in this task.".to_string())
 				}
 				else
 				{
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+					spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(AcodecAddon)
 				}
 			}
@@ -50,8 +50,7 @@ impl AcodecAddon
 				if al_init_acodec_addon() != 0
 				{
 					initialized = true;
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+					spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(AcodecAddon)
 				}
 				else

--- a/allegro_audio-sys/build.rs
+++ b/allegro_audio-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_audio-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_audio-sys/build.rs
+++ b/allegro_audio-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_audio{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_audio-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro_audio{}{}", static_, debug);
+    }
 }

--- a/allegro_audio-sys/src/macros.rs
+++ b/allegro_audio-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_audio-sys/src/rust_util.rs
+++ b/allegro_audio-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_audio/src/addon.rs
+++ b/allegro_audio/src/addon.rs
@@ -34,7 +34,7 @@ impl AudioAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}
@@ -44,7 +44,7 @@ impl AudioAddon
 				if al_install_audio() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}

--- a/allegro_audio/src/addon.rs
+++ b/allegro_audio/src/addon.rs
@@ -34,7 +34,8 @@ impl AudioAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -43,7 +44,8 @@ impl AudioAddon
 				if al_install_audio() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}
 				else

--- a/allegro_audio/src/addon.rs
+++ b/allegro_audio/src/addon.rs
@@ -2,14 +2,16 @@
 //
 // All rights reserved. Distributed under ZLib. For full terms see the file LICENSE.
 
+#![allow(non_upper_case_globals)]
+
 use allegro::Core;
 use allegro_audio_sys::*;
 
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 static mut initialized: bool = false;
-#[thread_local]
-static mut spawned_on_this_thread: bool = false;
+thread_local!(static spawned_on_this_thread: RefCell<bool> = RefCell::new(false));
 
 pub struct AudioAddon
 {
@@ -28,14 +30,13 @@ impl AudioAddon
 		{
 			if initialized
 			{
-				if spawned_on_this_thread
+				if spawned_on_this_thread.with(|x| *x.borrow())
 				{
 					Err("The audio addon has already been created in this task.".to_string())
 				}
 				else
 				{
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+					spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -44,8 +45,7 @@ impl AudioAddon
 				if al_install_audio() != 0
 				{
 					initialized = true;
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+					spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(AudioAddon{ core_mutex: core.get_core_mutex() })
 				}
 				else

--- a/allegro_audio/src/macros.rs
+++ b/allegro_audio/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_dialog-sys/src/macros.rs
+++ b/allegro_dialog-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_dialog-sys/src/rust_util.rs
+++ b/allegro_dialog-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_dialog/src/lib.rs
+++ b/allegro_dialog/src/lib.rs
@@ -65,7 +65,7 @@ impl DialogAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(DialogAddon)
 				}
@@ -75,7 +75,7 @@ impl DialogAddon
 				if al_init_native_dialog_addon() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(DialogAddon)
 				}

--- a/allegro_dialog/src/lib.rs
+++ b/allegro_dialog/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(thread_local)]
 #![feature(optin_builtin_traits)]
 #![feature(libc)]
+#![allow(non_upper_case_globals)]
 
 extern crate "allegro_dialog-sys" as allegro_dialog_sys;
 extern crate allegro;
@@ -16,6 +17,7 @@ extern crate libc;
 use allegro::{Core, Flag, Display};
 use allegro_dialog_sys::*;
 
+use std::cell::RefCell;
 use std::ffi::CString;
 
 #[macro_use]
@@ -41,8 +43,7 @@ pub enum MessageBoxResult
 }
 
 static mut initialized: bool = false;
-#[thread_local]
-static mut spawned_on_this_thread: bool = false;
+thread_local!(static spawned_on_this_thread: RefCell<bool> = RefCell::new(false));
 
 #[allow(missing_copy_implementations)]
 pub struct DialogAddon;
@@ -59,14 +60,13 @@ impl DialogAddon
 		{
 			if initialized
 			{
-				if spawned_on_this_thread
+				if spawned_on_this_thread.with(|x| *x.borrow())
 				{
 					Err("The dialog addon has already been created in this task.".to_string())
 				}
 				else
 				{
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+                    spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(DialogAddon)
 				}
 			}
@@ -75,8 +75,7 @@ impl DialogAddon
 				if al_init_native_dialog_addon() != 0
 				{
 					initialized = true;
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+                    spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(DialogAddon)
 				}
 				else

--- a/allegro_dialog/src/lib.rs
+++ b/allegro_dialog/src/lib.rs
@@ -65,7 +65,8 @@ impl DialogAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(DialogAddon)
 				}
 			}
@@ -74,7 +75,8 @@ impl DialogAddon
 				if al_init_native_dialog_addon() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(DialogAddon)
 				}
 				else

--- a/allegro_dialog/src/macros.rs
+++ b/allegro_dialog/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_font-sys/build.rs
+++ b/allegro_font-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_font-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_font-sys/build.rs
+++ b/allegro_font-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_font{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_font-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro_font{}{}", static_, debug);
+    }
 }

--- a/allegro_font-sys/src/macros.rs
+++ b/allegro_font-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_font-sys/src/rust_util.rs
+++ b/allegro_font-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_font/src/addon.rs
+++ b/allegro_font/src/addon.rs
@@ -34,7 +34,8 @@ impl FontAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -42,7 +43,8 @@ impl FontAddon
 			{
 				al_init_font_addon();
 				initialized = true;
-				spawned_on_this_thread = true;
+                // TODO: re-enable when this works on windows
+				// spawned_on_this_thread = true;
 				Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 			}
 		}

--- a/allegro_font/src/addon.rs
+++ b/allegro_font/src/addon.rs
@@ -2,14 +2,16 @@
 //
 // All rights reserved. Distributed under ZLib. For full terms see the file LICENSE.
 
+#![allow(non_upper_case_globals)]
+
+use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
 use allegro::Core;
 use allegro_font_sys::*;
 
 static mut initialized: bool = false;
-#[thread_local]
-static mut spawned_on_this_thread: bool = false;
+thread_local!(static spawned_on_this_thread: RefCell<bool> = RefCell::new(false));
 
 pub struct FontAddon
 {
@@ -28,14 +30,13 @@ impl FontAddon
 		{
 			if initialized
 			{
-				if spawned_on_this_thread
+				if spawned_on_this_thread.with(|x| *x.borrow())
 				{
 					Err("The font addon has already been created in this task.".to_string())
 				}
 				else
 				{
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+					spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -43,8 +44,7 @@ impl FontAddon
 			{
 				al_init_font_addon();
 				initialized = true;
-				// TODO: re-enable when this works on windows
-				// spawned_on_this_thread = true;
+                spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 				Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 			}
 		}

--- a/allegro_font/src/addon.rs
+++ b/allegro_font/src/addon.rs
@@ -34,7 +34,7 @@ impl FontAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 				}
@@ -43,7 +43,7 @@ impl FontAddon
 			{
 				al_init_font_addon();
 				initialized = true;
-                // TODO: re-enable when this works on windows
+				// TODO: re-enable when this works on windows
 				// spawned_on_this_thread = true;
 				Ok(FontAddon{ core_mutex: core.get_core_mutex() })
 			}

--- a/allegro_font/src/macros.rs
+++ b/allegro_font/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_image-sys/Cargo.toml
+++ b/allegro_image-sys/Cargo.toml
@@ -21,3 +21,8 @@ path = "src/lib.rs"
 link_none = []
 link_debug = []
 link_static = []
+
+[dependencies.allegro-sys]
+
+path = "../allegro-sys"
+version = "=0.0.11" #auto

--- a/allegro_image-sys/build.rs
+++ b/allegro_image-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_image{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_image-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+	    println!("cargo:rustc-flags=-l allegro_image{}{}", static_, debug);
+    }
 }

--- a/allegro_image-sys/build.rs
+++ b/allegro_image-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_image-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_image-sys/src/rust_util.rs
+++ b/allegro_image-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_image/src/lib.rs
+++ b/allegro_image/src/lib.rs
@@ -44,7 +44,7 @@ impl ImageAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(ImageAddon)
 				}
@@ -54,7 +54,7 @@ impl ImageAddon
 				if al_init_image_addon() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(ImageAddon)
 				}

--- a/allegro_image/src/lib.rs
+++ b/allegro_image/src/lib.rs
@@ -9,35 +9,12 @@
 #![feature(optin_builtin_traits)]
 #![feature(libc)]
 
-extern crate allegro;
 extern crate libc;
+extern crate allegro;
+extern crate "allegro_image-sys" as ffi;
 
 use allegro::Core;
 use ffi::allegro_image::*;
-
-#[cfg(not(manual_link))]
-mod link_name
-{
-	#[link(name = "allegro_image")]
-	extern "C" {}
-}
-
-pub mod ffi
-{
-	pub use self::allegro_image::*;
-	pub mod allegro_image
-	{
-		use libc::*;
-		use allegro::c_bool;
-
-		extern "C"
-		{
-			pub fn al_init_image_addon() -> c_bool;
-			pub fn al_shutdown_image_addon();
-			pub fn al_get_allegro_image_version() -> uint32_t;
-		}
-	}
-}
 
 #[macro_use]
 mod macros;
@@ -67,7 +44,8 @@ impl ImageAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(ImageAddon)
 				}
 			}
@@ -76,7 +54,8 @@ impl ImageAddon
 				if al_init_image_addon() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(ImageAddon)
 				}
 				else

--- a/allegro_image/src/macros.rs
+++ b/allegro_image/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_primitives-sys/build.rs
+++ b/allegro_primitives-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_primitives-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_primitives-sys/build.rs
+++ b/allegro_primitives-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_primitives{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_primitives-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro_primitives{}{}", static_, debug);
+    }
 }

--- a/allegro_primitives-sys/src/macros.rs
+++ b/allegro_primitives-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_primitives-sys/src/rust_util.rs
+++ b/allegro_primitives-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_primitives/src/lib.rs
+++ b/allegro_primitives/src/lib.rs
@@ -61,7 +61,8 @@ impl PrimitivesAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -70,7 +71,8 @@ impl PrimitivesAddon
 				if al_init_primitives_addon() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}
 				else

--- a/allegro_primitives/src/lib.rs
+++ b/allegro_primitives/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![crate_name="allegro_primitives"]
 #![crate_type = "lib"]
+#![allow(non_upper_case_globals)]
 
 #![feature(thread_local)]
 #![feature(optin_builtin_traits)]
@@ -13,8 +14,8 @@ extern crate allegro;
 extern crate libc;
 extern crate "allegro_primitives-sys" as allegro_primitives_sys;
 
+use std::cell::RefCell;
 use std::ptr;
-
 use std::sync::{Arc, Mutex};
 
 use allegro::{Bitmap, BitmapLike, Core, Color};
@@ -22,8 +23,7 @@ use allegro_primitives_sys::*;
 use libc::*;
 
 static mut initialized: bool = false;
-#[thread_local]
-static mut spawned_on_this_thread: bool = false;
+thread_local!(static spawned_on_this_thread: RefCell<bool> = RefCell::new(false));
 
 #[repr(u32)]
 #[derive(Copy)]
@@ -55,14 +55,13 @@ impl PrimitivesAddon
 		{
 			if initialized
 			{
-				if spawned_on_this_thread
+				if spawned_on_this_thread.with(|x| *x.borrow())
 				{
 					Err("The primitives addon has already been created in this task.".to_string())
 				}
 				else
 				{
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+                    spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}
 			}
@@ -71,8 +70,7 @@ impl PrimitivesAddon
 				if al_init_primitives_addon() != 0
 				{
 					initialized = true;
-					// TODO: re-enable when this works on windows
-					// spawned_on_this_thread = true;
+                    spawned_on_this_thread.with(|x| *x.borrow_mut() = true);
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}
 				else

--- a/allegro_primitives/src/lib.rs
+++ b/allegro_primitives/src/lib.rs
@@ -61,7 +61,7 @@ impl PrimitivesAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}
@@ -71,7 +71,7 @@ impl PrimitivesAddon
 				if al_init_primitives_addon() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(PrimitivesAddon{ core_mutex: core.get_core_mutex() })
 				}

--- a/allegro_ttf-sys/build.rs
+++ b/allegro_ttf-sys/build.rs
@@ -28,7 +28,7 @@ fn main()
         // Windows needs a little extra help.
         let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
 	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
-	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-search={}\\lib", home);
 	    println!("cargo:rustc-link-lib=allegro_ttf-{}{}{}{}", version, static_, "-mt", debug);
     }
     else

--- a/allegro_ttf-sys/build.rs
+++ b/allegro_ttf-sys/build.rs
@@ -23,5 +23,16 @@ fn main()
 		Ok(_) => "-static"
 	};
 
-	println!("cargo:rustc-flags=-l allegro_ttf{}{}", static_, debug);
+	if cfg!(windows)
+	{
+        // Windows needs a little extra help.
+        let home = var("ALLEGRO_HOME").ok().expect("ALLEGRO_HOME must be set to the root of your Allegro 5 installation.");
+	    let version = var("ALLEGRO_VERSION").ok().expect("ALLEGRO_VERSION must be set to the version of Allegro 5 you have installed.");
+	    println!("cargo:rustc-link-search={}\\bin", home);
+	    println!("cargo:rustc-link-lib=allegro_ttf-{}{}{}{}", version, static_, "-mt", debug);
+    }
+    else
+    {
+        println!("cargo:rustc-flags=-l allegro_ttf{}{}", static_, debug);
+    }
 }

--- a/allegro_ttf-sys/src/macros.rs
+++ b/allegro_ttf-sys/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");

--- a/allegro_ttf-sys/src/rust_util.rs
+++ b/allegro_ttf-sys/src/rust_util.rs
@@ -1,1 +1,1 @@
-../../src/rust_util.rs
+include!("../../src/rust_util.rs");

--- a/allegro_ttf/src/lib.rs
+++ b/allegro_ttf/src/lib.rs
@@ -60,7 +60,7 @@ impl TtfAddon
 				}
 				else
 				{
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(TtfAddon)
 				}
@@ -70,7 +70,7 @@ impl TtfAddon
 				if al_init_ttf_addon() != 0
 				{
 					initialized = true;
-				    // TODO: re-enable when this works on windows
+					// TODO: re-enable when this works on windows
 					// spawned_on_this_thread = true;
 					Ok(TtfAddon)
 				}

--- a/allegro_ttf/src/lib.rs
+++ b/allegro_ttf/src/lib.rs
@@ -60,7 +60,8 @@ impl TtfAddon
 				}
 				else
 				{
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(TtfAddon)
 				}
 			}
@@ -69,7 +70,8 @@ impl TtfAddon
 				if al_init_ttf_addon() != 0
 				{
 					initialized = true;
-					spawned_on_this_thread = true;
+				    // TODO: re-enable when this works on windows
+					// spawned_on_this_thread = true;
 					Ok(TtfAddon)
 				}
 				else

--- a/allegro_ttf/src/macros.rs
+++ b/allegro_ttf/src/macros.rs
@@ -1,1 +1,1 @@
-../../src/common_macros.rs
+include!("../../src/common_macros.rs");


### PR DESCRIPTION
Trying to build the `allegro-sys` crate was failing because two files only contain a path to another Rust file. Wrapping those paths with the `include!` macro fixes it.