### PR TITLE
Fix link_static for allegro_image

### DIFF
--- a/allegro_image/src/lib.rs
+++ b/allegro_image/src/lib.rs
@@ -12,13 +12,6 @@ extern crate libc;
 use allegro::Core;
 use ffi::allegro_image::*;
 
-#[cfg(not(manual_link))]
-mod link_name
-{
-	#[link(name = "allegro_image")]
-	extern "C" {}
-}
-
 pub mod ffi
 {
 	pub use self::allegro_image::*;


### PR DESCRIPTION
From looking through previous commits, it seems like 'manual_link' is legacy. It stops the `link_static` feature flag from taking effect.

Edit: Ah, this breaks the normal build without the feature flags.