### PR TITLE
autoderive Eq and Hash for KeyCode

### DIFF
--- a/allegro/src/keycodes.rs
+++ b/allegro/src/keycodes.rs
@@ -8,7 +8,7 @@ use libc::*;
 use std::mem;
 
 #[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum KeyCode
 {
 	A = 1,


### PR DESCRIPTION
Related to https://github.com/SiegeLord/RustAllegro/issues/8

E.g.

```rust
let pressed_keys = HashSet::new();

match queue.wait_for_event() {
  KeyDown { keycode: k, .. } => {
    pressed_keys.insert(k);
  }
  KeyUp { keycode: k, .. } => {
    pressed_keys.remove(&k);
  },
  _ => (),
}
```