### PR TITLE
Add documentation for set_target_bitmap

### DIFF
--- a/allegro/src/core.rs
+++ b/allegro/src/core.rs
@@ -562,6 +562,17 @@ impl Core
 		unsafe { mem::transmute(al_get_new_bitmap_format() as u32) }
 	}
 
+	 
+	/// This function is used to set the target bitmap that allegro draws to.
+	/// ```
+	/// // How to set target bitmap similar to al_set_target_bitmap
+	/// // For a more complete example look at example/example.rs
+	/// use allegro::*;
+	/// let core = Core::init().unwrap();
+	/// let bmp = Bitmap::new(&core, 400, 400).unwrap();
+	/// core.set_target_bitmap(Some(&map));
+	/// ```
+	
 	pub fn set_target_bitmap<T: BitmapLike>(&self, bmp: Option<&T>)
 	{
 		unsafe {


### PR DESCRIPTION
Just testing the waters to see if any documentation updates on the functions would be desired or not. I had trouble figuring out how to use the core set_target_bitmap function and thought an example like this would have been helpful.

